### PR TITLE
Adding outputs for subnet IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,56 @@ A terraform module that takes a simple approach to setting up a VPC with all the
 
 ## Features
 
-  1. Creates VPC, NAT gateways, routing tables, routes. Unlimited quantity of private/public subnets-per-AZ based on your input.
+  1. Creates VPC, NAT gateways, routing tables, routes. Up to 10 private, and 10 public, subnets-per-AZ based on your input.
   1. Automatically discover availability zones.
   1. Automatically calculate CIDR ranges based on quantity of availability zones and the size you want the subnets to be.
   1. Create two NAT Gateways and assign them to subnets on an odd/even basis for multi-AZ.
   1. Resists the temptation to allow for snowflake customization features like VPC Peering, VPN routing, DHCP Options, etc. Keep it simple, when possible.
+
+## Outputs
+
+Supported module outputs are:
+  1. `default_security_group_id` (string)
+  1. `private_subnet_ids` (map)
+  1. `public_subnet_ids` (map)
+  1. `vpc_id` (string)
+
+Example of using subnet ID map, assuming you called it via the name `module "vpc" {}`:
+```terraform
+resource "aws_autoscaling_group" "main" {
+  name                = "foobar3-terraform-test"
+
+  ...omitted...
+  vpc_zone_identifier = [ "${module.vpc.private_subnet_ids["app"]}" ]
+}
+```
+
+Example console output:
+```
+default_security_group_id = sg-286b0e60
+private_subnet_ids = {
+  app1 = [subnet-17f47c5d subnet-4833f614 subnet-b774b8d0 subnet-9d8543b3 subnet-eb9884d4 subnet-5548dd5a]
+  app2 = [subnet-a39584c7 subnet-f512b3fa subnet-95c7eaaa subnet-3ca49461 subnet-a14d7f8e subnet-d7ff3b9d]
+  db = [subnet-884476a7 subnet-8014b58f subnet-2bf33761 subnet-b8cfe287 subnet-bca090e1 subnet-9f9e8ffb]
+  unused3 = []
+  unused4 = []
+  unused5 = []
+  unused6 = []
+  unused7 = []
+  unused8 = []
+  unused9 = []
+}
+public_subnet_ids = {
+  lb = [subnet-b5fe76ff subnet-7923e625 subnet-1d7fb37a subnet-767dba58 subnet-05e1fd3a subnet-fc58cdf3]
+  bastion = [subnet-c02509ef subnet-472b2523 subnet-7c01f636 subnet-4f614312 subnet-626db46d subnet-2b9cc614]
+  unused2 = []
+  unused3 = []
+  unused4 = []
+  unused5 = []
+  unused6 = []
+  unused7 = []
+  unused8 = []
+  unused9 = []
+}
+vpc_id = vpc-e9f1cc92
+```

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,9 @@ resource "aws_subnet" "private" {
   cidr_block        = "${cidrsubnet("${aws_vpc.main.cidr_block}", "${var.cidr_newbits}", length(aws_subnet.public.*.id) + count.index)}"
 
   tags {
-    Name = "${trimspace(var.name_tag_prefix)} ${element(var.private_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Name        = "${trimspace(var.name_tag_prefix)} ${element(var.private_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Description = "${element(var.private_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Type        = "private"
   }
 }
 
@@ -32,7 +34,9 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags {
-    Name = "${trimspace(var.name_tag_prefix)} ${element(var.public_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Name        = "${trimspace(var.name_tag_prefix)} ${element(var.public_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Description = "${element(var.public_subnet_nametags, ceil(count.index / length(data.aws_availability_zones.available.names)))}"
+    Type        = "public"
   }
 }
 
@@ -60,6 +64,7 @@ resource "aws_route_table" "private" {
 
   tags {
     Name = "${trimspace(var.name_tag_prefix)} private"
+    Type = "private"
   }
 }
 
@@ -68,6 +73,7 @@ resource "aws_route_table" "public" {
 
   tags {
     Name = "${trimspace(var.name_tag_prefix)} public"
+    Type = "public"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,40 @@ output "vpc_id" {
 output "default_security_group_id" {
   value = "${aws_default_security_group.default.id}"
 }
+
+locals {
+  empty_list            = ["","","","","","","","","",""]
+
+  private_subnet_padded = "${concat(var.private_subnet_nametags,local.empty_list)}"
+  private_subnet_ids_type0 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,0)}")),list(""))}"
+  private_subnet_ids_type1 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,1)}")),list(""))}"
+  private_subnet_ids_type2 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,2)}")),list(""))}"
+  private_subnet_ids_type3 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,3)}")),list(""))}"
+  private_subnet_ids_type4 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,4)}")),list(""))}"
+  private_subnet_ids_type5 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,5)}")),list(""))}"
+  private_subnet_ids_type6 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,6)}")),list(""))}"
+  private_subnet_ids_type7 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,7)}")),list(""))}"
+  private_subnet_ids_type8 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,8)}")),list(""))}"
+  private_subnet_ids_type9 = "${coalescelist(matchkeys(aws_subnet.private.*.id, aws_subnet.private.*.tags.Description,list("${element(local.private_subnet_padded,9)}")),list(""))}"
+
+  public_subnet_padded = "${concat(var.public_subnet_nametags,local.empty_list)}"
+  public_subnet_ids_type0 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,0)}")),list(""))}"
+  public_subnet_ids_type1 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,1)}")),list(""))}"
+  public_subnet_ids_type2 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,2)}")),list(""))}"
+  public_subnet_ids_type3 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,3)}")),list(""))}"
+  public_subnet_ids_type4 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,4)}")),list(""))}"
+  public_subnet_ids_type5 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,5)}")),list(""))}"
+  public_subnet_ids_type6 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,6)}")),list(""))}"
+  public_subnet_ids_type7 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,7)}")),list(""))}"
+  public_subnet_ids_type8 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,8)}")),list(""))}"
+  public_subnet_ids_type9 = "${coalescelist(matchkeys(aws_subnet.public.*.id, aws_subnet.public.*.tags.Description,list("${element(local.public_subnet_padded,9)}")),list(""))}"
+
+}
+
+output "private_subnet_ids" {
+  value = "${map(coalesce(element(local.private_subnet_padded,0),"unused0"),local.private_subnet_ids_type0,coalesce(element(local.private_subnet_padded,1),"unused1"),local.private_subnet_ids_type1,coalesce(element(local.private_subnet_padded,2),"unused2"),local.private_subnet_ids_type2,coalesce(element(local.private_subnet_padded,3),"unused3"),local.private_subnet_ids_type3,coalesce(element(local.private_subnet_padded,4),"unused4"),local.private_subnet_ids_type4,coalesce(element(local.private_subnet_padded,5),"unused5"),local.private_subnet_ids_type5,coalesce(element(local.private_subnet_padded,6),"unused6"),local.private_subnet_ids_type6,coalesce(element(local.private_subnet_padded,7),"unused7"),local.private_subnet_ids_type7,coalesce(element(local.private_subnet_padded,8),"unused8"),local.private_subnet_ids_type8,coalesce(element(local.private_subnet_padded,9),"unused9"),local.private_subnet_ids_type9)}"
+}
+
+output "public_subnet_ids" {
+  value = "${map(coalesce(element(local.public_subnet_padded,0),"unused0"),local.public_subnet_ids_type0,coalesce(element(local.public_subnet_padded,1),"unused1"),local.public_subnet_ids_type1,coalesce(element(local.public_subnet_padded,2),"unused2"),local.public_subnet_ids_type2,coalesce(element(local.public_subnet_padded,3),"unused3"),local.public_subnet_ids_type3,coalesce(element(local.public_subnet_padded,4),"unused4"),local.public_subnet_ids_type4,coalesce(element(local.public_subnet_padded,5),"unused5"),local.public_subnet_ids_type5,coalesce(element(local.public_subnet_padded,6),"unused6"),local.public_subnet_ids_type6,coalesce(element(local.public_subnet_padded,7),"unused7"),local.public_subnet_ids_type7,coalesce(element(local.public_subnet_padded,8),"unused8"),local.public_subnet_ids_type8,coalesce(element(local.public_subnet_padded,9),"unused9"),local.public_subnet_ids_type9)}"
+}


### PR DESCRIPTION
Terraform lacks `count` on output. I'm not happy with what I had to do here. However I do believe it's within this project's goals to be able to configure multiple subnet types, and therefore you must be able to get the `subnet-id`s from output. This is the only way I could figure it out without iteration being a feature.